### PR TITLE
THU/delete_scenario_PROD-7543

### DIFF
--- a/src/ScenarioManagerTreeList/components/ScenarioNode/ScenarioNode.js
+++ b/src/ScenarioManagerTreeList/components/ScenarioNode/ScenarioNode.js
@@ -1,19 +1,32 @@
 // Copyright (c) Cosmo Tech.
 // Licensed under the MIT license.
 
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
-import { Typography } from '@material-ui/core';
+import { IconButton, Typography } from '@material-ui/core';
+import DeleteForeverIcon from '@material-ui/icons/DeleteForever';
 import { DatasetUtils } from '@cosmotech/core';
+import { ConfirmDeleteDialog } from './components';
 import useStyles from './style';
 
 const ScenarioNode = ({
   datasets,
-  scenario
+  scenario,
+  showDeleteIcon,
+  deleteScenario
 }) => {
   const classes = useStyles();
   const { t } = useTranslation();
+
+  const [isConfirmDialogOpen, setIsConfirmDialogOpen] = useState(false);
+  const openConfirmDialog = () => { setIsConfirmDialogOpen(true); };
+  const closeConfirmDialog = () => { setIsConfirmDialogOpen(false); };
+
+  function confirmScenarioDelete () {
+    closeConfirmDialog();
+    deleteScenario(scenario.id);
+  }
 
   function getStatusLabel () {
     return t('commoncomponents.scenariomanager.treelist.node.status.label', 'Run status') + ':';
@@ -35,11 +48,29 @@ const ScenarioNode = ({
 
   return (
     <React.Fragment>
+      <ConfirmDeleteDialog
+        open={isConfirmDialogOpen}
+        closeDialog={ closeConfirmDialog }
+        confirmDelete={ confirmScenarioDelete }
+      >
+      </ConfirmDeleteDialog>
       <Typography className={classes.scenarioHeader} color="textSecondary" gutterBottom>
         <span>
           <span className={classes.scenarioHeaderItem}>{scenario.ownerName}</span>
           <span className={classes.scenarioHeaderItem}>-</span>
           <span className={classes.scenarioHeaderItem}>{scenario.creationDate.toLocaleString()}</span>
+          {
+            showDeleteIcon && (
+              <IconButton
+                color="default"
+                aria-label="delete scenario"
+                size="small"
+                onClick={ openConfirmDialog }
+              >
+                <DeleteForeverIcon fontSize="small"/>
+              </IconButton>
+            )
+          }
         </span>
       </Typography>
       <Typography className={classes.scenarioTitle} variant="h4" data-content={scenario.name}>
@@ -63,7 +94,9 @@ const ScenarioNode = ({
 
 ScenarioNode.propTypes = {
   datasets: PropTypes.array.isRequired,
-  scenario: PropTypes.object.isRequired
+  scenario: PropTypes.object.isRequired,
+  showDeleteIcon: PropTypes.bool.isRequired,
+  deleteScenario: PropTypes.func.isRequired
 };
 
 function getStatusClassName (classes, scenarioState) {

--- a/src/ScenarioManagerTreeList/components/ScenarioNode/components/ConfirmDeleteDialog/ConfirmDeleteDialog.js
+++ b/src/ScenarioManagerTreeList/components/ScenarioNode/components/ConfirmDeleteDialog/ConfirmDeleteDialog.js
@@ -1,0 +1,77 @@
+// Copyright (c) Cosmo Tech.
+// Licensed under the MIT license.
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  makeStyles
+} from '@material-ui/core';
+
+const useStyles = makeStyles(theme => ({
+  root: {
+    height: '100%'
+  },
+  dialogContent: {
+    marginTop: '16px'
+  },
+  dialogActions: {
+    marginRight: '4px',
+    marginBottom: '4px'
+  }
+}));
+
+const ConfirmDeleteDialog = ({
+  open,
+  closeDialog,
+  confirmDelete
+}) => {
+  const classes = useStyles();
+  const { t } = useTranslation();
+
+  return (
+    <Dialog
+      className={classes.root}
+      open={open}
+      onClose={closeDialog}
+      aria-labelledby="confirm-scenario-delete"
+      aria-describedby="confirm-scenario-delete-description"
+    >
+      <DialogTitle id="confirm-scenario-delete">
+        {t('commoncomponents.dialog.confirm.delete.title', 'Confirm delete?')}
+      </DialogTitle>
+      <DialogContent className={classes.dialogContent}>
+        <DialogContentText id="confirm-scenario-delete-description">
+          {
+            t('commoncomponents.dialog.confirm.delete.description',
+              'The scenario will be deleted. If this scenario has children, ' +
+              'then its parent will become the new parent of all these scenarios.'
+            )
+          }
+        </DialogContentText>
+      </DialogContent>
+      <DialogActions className={classes.dialogActions}>
+        <Button onClick={closeDialog} color="primary" autoFocus>
+          {t('commoncomponents.dialog.confirm.delete.button.cancel', 'Cancel')}
+        </Button>
+        <Button onClick={confirmDelete} color="primary">
+          {t('commoncomponents.dialog.confirm.delete.button.confirm', 'Confirm')}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+};
+
+ConfirmDeleteDialog.propTypes = {
+  open: PropTypes.bool.isRequired,
+  closeDialog: PropTypes.func.isRequired,
+  confirmDelete: PropTypes.func.isRequired
+};
+
+export default ConfirmDeleteDialog;

--- a/src/ScenarioManagerTreeList/components/ScenarioNode/components/ConfirmDeleteDialog/index.js
+++ b/src/ScenarioManagerTreeList/components/ScenarioNode/components/ConfirmDeleteDialog/index.js
@@ -1,4 +1,4 @@
 // Copyright (c) Cosmo Tech.
 // Licensed under the MIT license.
 
-export { default as ScenarioNode } from './ScenarioNode';
+export { default } from './ConfirmDeleteDialog';

--- a/src/ScenarioManagerTreeList/components/ScenarioNode/components/index.js
+++ b/src/ScenarioManagerTreeList/components/ScenarioNode/components/index.js
@@ -1,0 +1,4 @@
+// Copyright (c) Cosmo Tech.
+// Licensed under the MIT license.
+
+export { default as ConfirmDeleteDialog } from './ConfirmDeleteDialog';


### PR DESCRIPTION
In ScenarioManagerTreeList component:
* add deleteScenario & userId props to be able to delete scenarios (if the current user is the scenario owner)
* on scenarios tree construction & usage in the webapp, use  a cache to remember whether or not a scenario node has been expanded by the user
* on scenario delete, refresh the tree data, and use cache to keep expanded nodes
* add confirmation dialog