### PR TITLE
THU/scenario_validation_status_chip

### DIFF
--- a/doc/src/misc/ScenarioValidationStatusChip.mdx
+++ b/doc/src/misc/ScenarioValidationStatusChip.mdx
@@ -1,0 +1,41 @@
+---
+name: ScenarioValidationStatusChip
+route: /ScenarioValidationStatusChip
+menu: Misc
+---
+
+import { Playground, Props } from 'docz';
+import { ScenarioValidationStatusChip } from '@cosmotech/ui';
+
+# ScenarioValidationStatusChip
+
+This component is a chip that can be used to display the current scenario validation status.
+
+## Props
+
+<Props of={ScenarioValidationStatusChip} />
+
+## Basic Usage
+
+When the validation status is 'Validated' or 'Rejected', the chip is displayed.
+When the validation status is 'Draft' or 'Unknown', the chip is not displayed.
+When the validation status is 'Loading', a spinner is displayed instead of the chip.
+
+<Playground>
+  <ScenarioValidationStatusChip status="Unknown" />
+  <ScenarioValidationStatusChip status="Draft" />
+  <ScenarioValidationStatusChip status="Loading" />
+  <ScenarioValidationStatusChip status="Validated" />
+  <ScenarioValidationStatusChip status="Rejected" />
+</Playground>
+
+## Delete button
+
+If the prop onDelete is provided, a delete button is displayed when the status is rejected or validated. This button
+calls the prop function onDelete when it is clicked on.
+
+<Playground>
+  <ScenarioValidationStatusChip status="Draft" onDelete={() => console.log('delete')} />
+  <ScenarioValidationStatusChip status="Validated" onDelete={() => console.log('delete')} />
+  <ScenarioValidationStatusChip status="Rejected" onDelete={() => console.log('delete')} />
+</Playground>

--- a/src/cards/ScenarioNode/ScenarioNode.js
+++ b/src/cards/ScenarioNode/ScenarioNode.js
@@ -24,6 +24,7 @@ import {
 } from '@material-ui/icons';
 import { DatasetUtils } from '@cosmotech/core';
 import { ConfirmDeleteDialog } from './components';
+import { ScenarioValidationStatusChip } from '../../misc';
 import useStyles from './style';
 
 export const ScenarioNode = ({
@@ -131,6 +132,17 @@ export const ScenarioNode = ({
     );
   };
 
+  const getValidationStatus = (clickable = true) => {
+    const className = clickable ? classes.clickableValidationStatusChip : classes.nonClickableValidationStatusChip;
+    return (
+      <ScenarioValidationStatusChip
+        className={className}
+        status={scenario.validationStatus || 'Unknown'}
+        labels={labels.validationStatus}
+      />
+    );
+  };
+
   const getScenarioName = () => {
     return (
       <Tooltip key="scenario-name-tooltip" title={scenario.name}>
@@ -150,11 +162,11 @@ export const ScenarioNode = ({
     );
   };
 
-  const getScenarioNameAndStatus = () => {
+  const getScenarioNameAndValidationStatus = (isValidationChipClickable = true) => {
     return (
       <>
         {getScenarioName()}
-        {getStatusIcon(false)}
+        {getValidationStatus(isValidationChipClickable)}
       </>
     );
   };
@@ -173,7 +185,7 @@ export const ScenarioNode = ({
   const getScenarioHeader = () => {
     return (
       <Box className={classes.scenarioHeader} flexGrow={1}>
-        {isExpanded ? getScenarioCreationData() : getScenarioNameAndStatus()}
+        {isExpanded ? getScenarioCreationData() : getScenarioNameAndValidationStatus(true)}
       </Box>
     );
   };
@@ -185,7 +197,10 @@ export const ScenarioNode = ({
 
   const getAccordionSummary = () => {
     return (
-      <AccordionSummary className={classes.accordionSummary} expandIcon={<ExpandMoreIcon />}>
+      <AccordionSummary
+        className={classes.accordionSummary}
+        expandIcon={<ExpandMoreIcon data-cy="expand-accordion-button" />}
+      >
         {getScenarioHeader()}
         {showDeleteIcon && (
           <IconButton
@@ -218,7 +233,7 @@ export const ScenarioNode = ({
   const getAccordionDetails = () => {
     return (
       <AccordionDetails className={classes.scenarioDetailsContainer}>
-        {getScenarioName()}
+        <div className={classes.scenarioDetailsNameLine}>{getScenarioNameAndValidationStatus(false)}</div>
         {getDetailedStatus()}
         <Typography className={classes.cardLabel}>{getDatasetsLabel()}</Typography>
         <Typography>
@@ -285,16 +300,20 @@ ScenarioNode.propTypes = {
         status: 'string',
         successful: 'string',
         failed: 'string',
-        created: 'string'
-        delete: 'string'
-        redirect: 'string' 
+        created: 'string',
+        delete: 'string',
+        redirect: 'string',
         running: 'string',
         dataset: 'string',
         deleteDialog : {
           title: 'string',
           description: 'string',
           cancel: 'string',
-          confirm: 'string'
+          confirm: 'string',
+        }
+        validationStatus : {
+          rejected: 'string',
+          validated: 'string',
         }
    *   }
    * </pre>
@@ -313,6 +332,10 @@ ScenarioNode.propTypes = {
       description: PropTypes.string.isRequired,
       cancel: PropTypes.string.isRequired,
       confirm: PropTypes.string.isRequired,
+    }).isRequired,
+    validationStatus: PropTypes.shape({
+      rejected: PropTypes.string.isRequired,
+      validated: PropTypes.string.isRequired,
     }).isRequired,
   }),
   /**
@@ -333,5 +356,9 @@ ScenarioNode.defaultProps = {
     delete: 'Delete this scenario',
     redirect: 'Redirect to scenario view',
     dataset: 'Datasets',
+    validationStatus: {
+      rejected: 'Rejected',
+      validated: 'Validated',
+    },
   },
 };

--- a/src/cards/ScenarioNode/style.js
+++ b/src/cards/ScenarioNode/style.js
@@ -63,6 +63,7 @@ const useStyles = makeStyles((theme) => ({
     display: 'flex',
     flexDirection: 'row',
     justifyContent: 'flex-start',
+    alignItems: 'center',
   },
   scenarioHeaderItem: {
     marginRight: '24px',
@@ -73,6 +74,11 @@ const useStyles = makeStyles((theme) => ({
     flexDirection: 'column',
     justifyContent: 'space-between',
     alignItems: 'stretch',
+  },
+  scenarioDetailsNameLine: {
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'center',
   },
   scenarioDetailsStatusContainer: {
     display: 'flex',
@@ -129,6 +135,17 @@ const useStyles = makeStyles((theme) => ({
   },
   datasets: {
     marginLeft: '15px',
+  },
+  clickableValidationStatusChip: {
+    marginLeft: '10px',
+    height: '24px',
+    '&:hover': {
+      cursor: 'pointer',
+    },
+  },
+  nonClickableValidationStatusChip: {
+    marginLeft: '10px',
+    height: '24px',
   },
 }));
 

--- a/src/charts/ScenarioManagerTreeList/ScenarioManagerTreeList.js
+++ b/src/charts/ScenarioManagerTreeList/ScenarioManagerTreeList.js
@@ -25,6 +25,18 @@ const initNodesDict = (scenarios, defaultExpanded) => {
   return nodesDict;
 };
 
+const filterMatchesName = (scenario, searchStr) => scenario.name.toLowerCase().indexOf(searchStr.toLowerCase()) !== -1;
+const filterMatchesValidationStatus = (labels, scenario, searchStr) => {
+  if (!scenario.validationStatus) return false;
+  const validationStatusLabel = labels.validationStatus?.[scenario.validationStatus.toLowerCase()]?.toLowerCase();
+  return validationStatusLabel && validationStatusLabel.indexOf(searchStr.toLowerCase()) !== -1;
+};
+const filterMatchesRunStatus = (labels, scenario, searchStr) => {
+  if (!scenario.state) return false;
+  const runStatusLabel = labels?.[scenario.state.toLowerCase()]?.toLowerCase();
+  return runStatusLabel && runStatusLabel.indexOf(searchStr.toLowerCase()) !== -1;
+};
+
 export const ScenarioManagerTreeList = (props) => {
   const classes = useStyles();
   const {
@@ -125,12 +137,12 @@ export const ScenarioManagerTreeList = (props) => {
       return;
     }
     // Otherwise, filter scenarios based on their name
-    const filtered = [];
-    for (const scenario of scenarios) {
-      if (scenario.name.toLowerCase().indexOf(searchStr.toLowerCase()) !== -1) {
-        filtered.push(scenario);
-      }
-    }
+    const filtered = scenarios.filter(
+      (scenario) =>
+        filterMatchesName(scenario, searchStr) ||
+        filterMatchesValidationStatus(labels, scenario, searchStr) ||
+        filterMatchesRunStatus(labels, scenario, searchStr)
+    );
     // Format list and set as tree data
     setTreeData(formatScenariosToRSTList(filtered));
   };
@@ -311,7 +323,12 @@ ScenarioManagerTreeList.defaultProps = {
     searchField: 'Filter',
     toolbar: {
       expandAll: 'Expand all',
+      expandTree: 'Expand tree',
       collapseAll: 'Collapse all',
+    },
+    validationStatus: {
+      rejected: 'Rejected',
+      validated: 'Validated',
     },
   },
 };

--- a/src/index.js
+++ b/src/index.js
@@ -18,4 +18,4 @@ export {
   TABLE_DATA_STATUS,
 } from './inputs';
 export { UserInfo, HelpMenu } from './menus';
-export { ErrorsPanel, PrivateRoute, PublicRoute, LoadingLine } from './misc';
+export { ErrorsPanel, PrivateRoute, PublicRoute, ScenarioValidationStatusChip, LoadingLine } from './misc';

--- a/src/inputs/HierarchicalComboBox/HierarchicalComboBox.js
+++ b/src/inputs/HierarchicalComboBox/HierarchicalComboBox.js
@@ -3,13 +3,37 @@
 
 import React from 'react';
 import PropTypes from 'prop-types';
-import { TextField, Tooltip } from '@material-ui/core';
+import { makeStyles, TextField, Tooltip } from '@material-ui/core';
 import Autocomplete from '@material-ui/lab/Autocomplete';
+import { ScenarioValidationStatusChip } from '../../misc';
 
-export const HierarchicalComboBox = ({ values, label, disabled, handleChange, renderInputToolType, ...props }) => {
+const useStyles = makeStyles((theme) => ({
+  validationStatusChip: {
+    height: '24px',
+    marginLeft: '10px',
+    '&:hover': {
+      cursor: 'pointer',
+    },
+  },
+}));
+
+export const HierarchicalComboBox = ({
+  values,
+  label,
+  labels,
+  disabled,
+  handleChange,
+  renderInputToolType,
+  ...props
+}) => {
+  const classes = useStyles();
+  // 'label' prop is deprecated but is still used as main source of data if provided, otherwise we fallback to the new
+  // prop labels.label
+  const mainLabel = label || labels.label;
   return (
     <Autocomplete
       {...props}
+      data-cy="scenario-selector"
       onChange={(event, node) => handleChange(event, node)}
       disableClearable
       disabled={disabled}
@@ -21,12 +45,23 @@ export const HierarchicalComboBox = ({ values, label, disabled, handleChange, re
         return (
           <span data-testid={'option-' + option.id} style={{ marginLeft: marginLeft }}>
             {option.name}
+            <ScenarioValidationStatusChip
+              className={classes.validationStatusChip}
+              status={option.validationStatus || 'Unknown'}
+              labels={labels.validationStatus}
+            />
           </span>
         );
       }}
       renderInput={(params) => (
         <Tooltip arrow title={renderInputToolType}>
-          <TextField {...params} data-cy="scenario-select-input" placeholder={label} label={label} variant="outlined" />
+          <TextField
+            {...params}
+            data-cy="scenario-select-input"
+            placeholder={mainLabel}
+            label={mainLabel}
+            variant="outlined"
+          />
         </Tooltip>
       )}
     />
@@ -35,9 +70,30 @@ export const HierarchicalComboBox = ({ values, label, disabled, handleChange, re
 
 HierarchicalComboBox.propTypes = {
   /**
-   * HierarchicalComboBox's label
+   * DEPRECATED HierarchicalComboBox's label. This prop is deprecated, use labels.label instead.
    */
   label: PropTypes.string,
+  /**
+   * Component's labels:
+   * Structure:
+   * <pre>
+     {
+       label: 'string',
+       validationStatus:
+       {
+         rejected: 'string',
+         validated: 'string',
+       }
+     }
+   * </pre>
+   */
+  labels: PropTypes.shape({
+    label: PropTypes.string,
+    validationStatus: PropTypes.shape({
+      rejected: PropTypes.string,
+      validated: PropTypes.string,
+    }),
+  }),
   /**
    * Function bound on onChange event
    */
@@ -62,4 +118,11 @@ HierarchicalComboBox.propTypes = {
 HierarchicalComboBox.defaultProps = {
   disabled: false,
   renderInputToolType: '',
+  labels: {
+    label: 'Scenario',
+    validationStatus: {
+      rejected: 'Rejected',
+      validated: 'Validated',
+    },
+  },
 };

--- a/src/misc/ScenarioValidationStatusChip/ScenarioValidationStatusChip.js
+++ b/src/misc/ScenarioValidationStatusChip/ScenarioValidationStatusChip.js
@@ -1,0 +1,115 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import clsx from 'clsx';
+import { Chip, CircularProgress, makeStyles } from '@material-ui/core';
+
+const useStyles = makeStyles((theme) => ({
+  validated: {
+    backgroundColor: theme.palette.success.main,
+    color: 'white',
+    '&:focus': {
+      backgroundColor: theme.palette.success.main,
+    },
+    '& .MuiChip-deleteIcon': {
+      color: 'white',
+    },
+  },
+  rejected: {
+    backgroundColor: theme.palette.error.main,
+    color: 'white',
+    '&:focus': {
+      backgroundColor: theme.palette.error.main,
+    },
+    '& .MuiChip-deleteIcon': {
+      color: 'white',
+    },
+  },
+}));
+
+export const ScenarioValidationStatusChip = (props) => {
+  const classes = useStyles();
+  const { labels, status, onDelete, className } = props;
+  const lowerCaseStatus = status?.toLowerCase() || 'unknown';
+
+  const getLabel = () => {
+    if (lowerCaseStatus in labels) {
+      return labels[lowerCaseStatus];
+    } else if (['draft', 'loading', 'unknown'].includes(lowerCaseStatus) === false) {
+      console.warn(`No label found for scenario status "${lowerCaseStatus}".`);
+    }
+    return 'Unknown';
+  };
+
+  const getClassName = () => {
+    let className = '';
+    switch (lowerCaseStatus) {
+      case 'validated':
+        className = classes.validated;
+        break;
+      case 'rejected':
+        className = classes.rejected;
+        break;
+      default:
+        break;
+    }
+    return className;
+  };
+
+  if (lowerCaseStatus === 'loading') {
+    return (
+      <CircularProgress
+        className={className}
+        color="inherit"
+        data-cy="scenario-validation-status-loading-spinner"
+        size="15px"
+      />
+    );
+  }
+
+  return lowerCaseStatus === 'rejected' || lowerCaseStatus === 'validated' ? (
+    <Chip
+      clickable={false}
+      data-cy="scenario-validation-status"
+      label={getLabel()}
+      onDelete={onDelete}
+      className={clsx(getClassName(), className)}
+    />
+  ) : null;
+};
+
+ScenarioValidationStatusChip.propTypes = {
+  /**
+   * Optional classname.
+   */
+  className: PropTypes.string,
+  /**
+   * Component's labels:
+   * Structure:
+   * <pre>
+     {
+       rejected: 'string',
+       validated: 'string',
+     }
+   * </pre>
+   */
+  labels: PropTypes.shape({
+    rejected: PropTypes.string,
+    validated: PropTypes.string,
+  }),
+  /**
+   * Function that will be called when users click on the "Delete" button. Can be used to clear the current status.
+   * This prop is optional: if it is not provided, the delete button in the chip will not be displayed.
+   */
+  onDelete: PropTypes.func,
+  /**
+   * Scenario status. Must be one of these values: 'Draft', 'Loading', 'Rejected', 'Validated' or 'Unknown'.
+   */
+  status: PropTypes.oneOf(['Draft', 'Loading', 'Rejected', 'Validated', 'Unknown']).isRequired,
+};
+
+ScenarioValidationStatusChip.defaultProps = {
+  labels: {
+    rejected: 'Rejected',
+    validated: 'Validated',
+  },
+};

--- a/src/misc/ScenarioValidationStatusChip/index.js
+++ b/src/misc/ScenarioValidationStatusChip/index.js
@@ -1,0 +1,4 @@
+// Copyright (c) Cosmo Tech.
+// Licensed under the MIT license.
+
+export { ScenarioValidationStatusChip } from './ScenarioValidationStatusChip';

--- a/src/misc/index.js
+++ b/src/misc/index.js
@@ -5,4 +5,5 @@ export { ErrorsPanel } from './ErrorsPanel';
 export { FixedRatioContainer } from './FixedRatioContainer';
 export { PublicRoute } from './PublicRoute';
 export { PrivateRoute } from './PrivateRoute';
+export { ScenarioValidationStatusChip } from './ScenarioValidationStatusChip';
 export { LoadingLine } from './LoadingLine';


### PR DESCRIPTION
This branch adds a new generic component `ScenarioValidationStatusChip` that displays a green or red chip if the provided scenario status is "Validated" or "Rejected". If the status is 'Draft' or 'Unknown', the chip is not displayed. If the status is 'Loading', a spinner is displayed instead.

The `ScenarioValidationStatusChip` component is then used in the `ScenarioManagerTreeList` and the HierarchicalComboxBox` components.