### PR TITLE
feat: highlight adjacent edges and new meta data fields

### DIFF
--- a/src/charts/CytoViz/CytoViz.js
+++ b/src/charts/CytoViz/CytoViz.js
@@ -97,11 +97,15 @@ export const CytoViz = (props) => {
     cytoscapeRef.removeAllListeners();
     // Prevent multiple selection & init elements selection behavior
     cytoscapeRef.on('select', 'node, edge', function (e) {
-      cytoscapeRef.elements().not(e.target).unselect();
+      cytoscapeRef.edges().data({ asInEdgeHighlighted: false, asOutEdgeHighlighted: false });
       const selectedElement = e.target;
+      selectedElement.select();
+      selectedElement.outgoers('edge').data('asOutEdgeHighlighted', true);
+      selectedElement.incomers('edge').data('asInEdgeHighlighted', true);
       setCurrentElementDetails(getElementDetailsCallback(selectedElement));
     });
     cytoscapeRef.on('unselect', 'node, edge', function (e) {
+      cytoscapeRef.edges().data({ asInEdgeHighlighted: false, asOutEdgeHighlighted: false });
       setCurrentElementDetails(null);
     });
     // Add handling of double click events

--- a/src/charts/CytoViz/components/ElementData/ElementData.js
+++ b/src/charts/CytoViz/components/ElementData/ElementData.js
@@ -7,7 +7,15 @@ import useStyles from './style';
 
 const _generateAttributeDetails = (classes, labels, attributeName, attributeValue) => {
   const attributeLabel = labels?.attributes?.[attributeName] || attributeName;
-  const attributesToIgnore = ['label', 'Label', 'parent', 'source', 'target'];
+  const attributesToIgnore = [
+    'label',
+    'Label',
+    'parent',
+    'source',
+    'target',
+    'asOutEdgeHighlighted',
+    'asInEdgeHighlighted',
+  ];
   if (attributesToIgnore.indexOf(attributeName) !== -1) {
     return null;
   }


### PR DESCRIPTION
- New attribute in edge.data: {asInEdgeHighlighted: boolean, asOutEdgeHighlighted: false}
- needed to be stored in data because sate variables of edges (selected, locked, activated, …) are changed depending on the semantics of the model.
- all attributes in the data field that begin with an underscore will be filtered out when passing them to the component
- remote branches OHOW/highlight_adj_edges_III (3) as well as OHOW/highlight_node_adjacent_edges can be deleted as well as this one after pull