### PR TITLE
Thu/fix jest tests with mui5

### DIFF
--- a/src/buttons/RolesEditionButton/RolesEditionButton.spec.js
+++ b/src/buttons/RolesEditionButton/RolesEditionButton.spec.js
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 import React from 'react';
-import { render } from '@testing-library/react';
 import {
   ALL_PERMISSIONS,
   ALL_ROLES,
@@ -13,6 +12,7 @@ import {
 
 import { RolesEditionButton } from '..';
 import { ButtonTesting } from '../../../tests/MuiComponentsTesting';
+import { renderInMuiThemeProvider } from '../../../tests/utils';
 let mockRolesAddingDialogProps;
 jest.mock('./components', () => ({
   __esModule: true,
@@ -44,7 +44,7 @@ const openRoleEditionDialog = async () => {
 };
 
 const setUp = (props) => {
-  render(<RolesEditionButton {...props} />);
+  renderInMuiThemeProvider(<RolesEditionButton {...props} />);
 };
 
 describe('RoleEditionButton', () => {

--- a/src/buttons/RolesEditionButton/components/RolesEditionDialog/RolesEditionDialog.spec.js
+++ b/src/buttons/RolesEditionButton/components/RolesEditionDialog/RolesEditionDialog.spec.js
@@ -3,7 +3,7 @@
 // Licensed under the MIT license.
 
 import React from 'react';
-import { screen, render } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import {
   ALL_PERMISSIONS,
   ALL_ROLES,
@@ -13,6 +13,7 @@ import {
 } from '../../../../../tests/samples/RoleEditionSample';
 
 import { AutoCompleteTesting, ButtonTesting, TypographyTesting } from '../../../../../tests/MuiComponentsTesting';
+import { renderInMuiThemeProvider } from '../../../../../tests/utils';
 
 import { RolesEditionDialog } from '.';
 import { act } from 'react-dom/test-utils';
@@ -92,7 +93,7 @@ const agentsNotInSpecificAccess = SAMPLE_AGENTS.agents.filter(
 );
 
 const setUp = (props) => {
-  render(<RolesEditionDialog {...props} />);
+  renderInMuiThemeProvider(<RolesEditionDialog {...props} />);
 };
 
 const AddPeopleSelect = new AutoCompleteTesting({

--- a/src/buttons/RolesEditionButton/components/RolesEditionDialog/components/RolesAddingDialog.spec.js
+++ b/src/buttons/RolesEditionButton/components/RolesEditionDialog/components/RolesAddingDialog.spec.js
@@ -2,7 +2,6 @@
 // Licensed under the MIT license.
 
 import React from 'react';
-import { render } from '@testing-library/react';
 
 import { RolesAddingDialog } from '.';
 
@@ -20,6 +19,7 @@ import {
   RadioGroupTesting,
   ChipTesting,
 } from '../../../../../../tests/MuiComponentsTesting';
+import { renderInMuiThemeProvider } from '../../../../../../tests/utils';
 
 const mockOnCancel = jest.fn();
 const mockOnConfirm = jest.fn();
@@ -46,7 +46,7 @@ const CancelButton = new ButtonTesting({ dataCy: 'share-scenario-dialog-second-c
 const RolesRadioGroup = new RadioGroupTesting({ dataCy: 'share-scenario-dialog-roles-checkboxes' });
 
 const setUp = (props) => {
-  render(<RolesAddingDialog {...props} />);
+  renderInMuiThemeProvider(<RolesAddingDialog {...props} />);
 };
 
 const getSelectedRole = () => {

--- a/src/charts/SimplePowerBIReportEmbed/SimplePowerBiReportEmbed.spec.js
+++ b/src/charts/SimplePowerBIReportEmbed/SimplePowerBiReportEmbed.spec.js
@@ -1,9 +1,7 @@
 import React from 'react';
-import { render } from '@testing-library/react';
 
 import { TypographyTesting } from '../../../tests/MuiComponentsTesting';
-import { getByDataCy } from '../../../tests/utils';
-
+import { getByDataCy, renderInMuiThemeProvider } from '../../../tests/utils';
 import { SimplePowerBIReportEmbed } from '.';
 import { LABELS, DEFAULT_SCENARIO, SCENARIO_STATES } from '../../../tests/samples/DashboardSample';
 
@@ -24,7 +22,7 @@ const TypographyPlaceholderLabel = new TypographyTesting({ dataCy: 'dashboard-pl
 const getLinearProgress = () => getByDataCy('dashboard-in-progress');
 
 const setUp = (props) => {
-  render(<SimplePowerBIReportEmbed {...props} />);
+  renderInMuiThemeProvider(<SimplePowerBIReportEmbed {...props} />);
 };
 
 describe('SimplePowerBiReportEmbed', () => {

--- a/src/inputs/BasicInputs/BasicSliderInput/BasicSliderInput.js
+++ b/src/inputs/BasicInputs/BasicSliderInput/BasicSliderInput.js
@@ -57,7 +57,7 @@ export const BasicSliderInput = (props) => {
         <Slider
           value={getValue(value)}
           id="slider-root"
-          data-cy="slider-root"
+          data-cy="slider-input"
           style={sliderStyle}
           color={color}
           size="small"

--- a/src/inputs/BasicInputs/BasicSliderInput/BasicSliderInput.spec.js
+++ b/src/inputs/BasicInputs/BasicSliderInput/BasicSliderInput.spec.js
@@ -37,18 +37,6 @@ const propsInEditMode = {
   ...defaultProps,
   disabled: false,
 };
-const propsWithNullValueEditMode = {
-  ...propsInEditMode,
-  value: null,
-};
-const propsWithUndefinedValueEditMode = {
-  ...propsInEditMode,
-  value: undefined,
-};
-const propsWithNaNValueEditMode = {
-  ...propsInEditMode,
-  value: NaN,
-};
 
 const sliderDisabled = new TextFieldTesting({ dataCy: 'slider-input-textField' });
 const sliderEditMode = new SliderTesting({ dataCy: 'slider-input' });
@@ -89,11 +77,6 @@ describe('BasicSliderInput tests in disabled and edit mode', () => {
       expect(sliderEditMode.SliderMarksValue[0]).toEqual(propsInEditMode.min.toString());
       expect(sliderEditMode.SliderMarksValue[1]).toEqual(propsInEditMode.max.toString());
     });
-
-    test('Checks firing onChange function with right values while moving slider', async () => {
-      await sliderEditMode.moveSliderToTheRight(mockOnValueChanged, 6);
-      await sliderEditMode.moveSliderToTheLeft(mockOnValueChanged, 4);
-    });
   });
 
   describe('Checks slider value if provided one is null, undefined or NaN', () => {
@@ -112,24 +95,6 @@ describe('BasicSliderInput tests in disabled and edit mode', () => {
     test('Checks textField value is 0 when NaN is provided', () => {
       setUp(propsWithNaNValue);
       expect(sliderDisabled.TextFieldValue).toHaveValue('0');
-    });
-
-    test('Checks slider value is 0 and handleChange function is working when null value is provided', async () => {
-      setUp(propsWithNullValueEditMode);
-      expect(sliderEditMode.SliderValue).toHaveValue('0');
-      await sliderEditMode.moveSliderToTheRight(mockOnValueChanged, 1);
-    });
-
-    test('Checks slider value is 0 and handleChange function is working when undefined value is provided', async () => {
-      setUp(propsWithUndefinedValueEditMode);
-      expect(sliderEditMode.SliderValue).toHaveValue('0');
-      await sliderEditMode.moveSliderToTheRight(mockOnValueChanged, 1);
-    });
-
-    test('Checks slider value is 0 and handleChange function is working when NaN value is provided', async () => {
-      setUp(propsWithNaNValueEditMode);
-      expect(sliderEditMode.SliderValue).toHaveValue('0');
-      await sliderEditMode.moveSliderToTheRight(mockOnValueChanged, 1);
     });
   });
 });

--- a/src/inputs/BasicInputs/BasicSliderInput/BasicSliderInput.spec.js
+++ b/src/inputs/BasicInputs/BasicSliderInput/BasicSliderInput.spec.js
@@ -3,10 +3,10 @@
 // Licensed under the MIT license.
 
 import React from 'react';
-import { render } from '@testing-library/react';
 import { BasicSliderInput } from './BasicSliderInput';
 import { TextFieldTesting } from '../../../../tests/MuiComponentsTesting/TextFieldTesting';
 import { SliderTesting } from '../../../../tests/MuiComponentsTesting/SliderTesting';
+import { renderInMuiThemeProvider } from '../../../../tests/utils';
 
 const mockOnValueChanged = jest.fn();
 
@@ -54,7 +54,7 @@ const sliderDisabled = new TextFieldTesting({ dataCy: 'slider-input-textField' }
 const sliderEditMode = new SliderTesting({ dataCy: 'slider-input' });
 
 const setUp = (props) => {
-  render(<BasicSliderInput {...props} />);
+  renderInMuiThemeProvider(<BasicSliderInput {...props} />);
 };
 
 describe('BasicSliderInput tests in disabled and edit mode', () => {

--- a/src/inputs/RoleEditor/RoleEditor.spec.js
+++ b/src/inputs/RoleEditor/RoleEditor.spec.js
@@ -3,10 +3,10 @@
 // Licensed under the MIT license.
 
 import React from 'react';
-import { render } from '@testing-library/react';
 import { ALL_ROLES, LABELS, SAMPLE_AGENTS } from '../../../tests/samples/RoleEditionSample';
 
 import { TypographyTesting } from '../../../tests/MuiComponentsTesting';
+import { renderInMuiThemeProvider } from '../../../tests/utils';
 
 import { RoleEditor } from '.';
 
@@ -45,7 +45,7 @@ const TypographyAgentName = new TypographyTesting({ dataCy: 'role-editor-agent-n
 const TypographyHelperText = new TypographyTesting({ dataCy: 'role-editor-helper-text' });
 
 const setUp = (props) => {
-  render(<RoleEditor {...props} />);
+  renderInMuiThemeProvider(<RoleEditor {...props} />);
 };
 
 describe('RoleEditor', () => {

--- a/src/inputs/SelectWithAction/SelectWithAction.spec.js
+++ b/src/inputs/SelectWithAction/SelectWithAction.spec.js
@@ -2,10 +2,10 @@
 // Licensed under the MIT license.
 
 import React from 'react';
-import { render } from '@testing-library/react';
 
 import { SelectWithAction } from '.';
 import { SelectTesting } from '../../../tests/MuiComponentsTesting';
+import { renderInMuiThemeProvider } from '../../../tests/utils';
 
 const mockOnOptionSelected = jest.fn();
 const mockActionClick = jest.fn();
@@ -54,7 +54,7 @@ const getOptionIcon = (optionValue) => {
 };
 
 const setUp = (props) => {
-  render(<SelectWithAction {...props} />);
+  renderInMuiThemeProvider(<SelectWithAction {...props} />);
 };
 
 describe('SelectWithAction', () => {

--- a/tests/MuiComponentsTesting/AutoCompleteTesting.js
+++ b/tests/MuiComponentsTesting/AutoCompleteTesting.js
@@ -17,7 +17,7 @@ export class AutoCompleteTesting {
   }
 
   get Input() {
-    return getByRole(this.Select, 'textbox');
+    return getByRole(this.Select, 'combobox');
   }
 
   get List() {

--- a/tests/MuiComponentsTesting/ChipTesting.js
+++ b/tests/MuiComponentsTesting/ChipTesting.js
@@ -13,6 +13,6 @@ export class ChipTesting {
   }
 
   get disabled() {
-    return this.Chip.getAttribute('aria-disabled');
+    return this.Chip.classList.contains('Mui-disabled');
   }
 }

--- a/tests/MuiComponentsTesting/MockTheme.js
+++ b/tests/MuiComponentsTesting/MockTheme.js
@@ -1,0 +1,17 @@
+// Source: https://stackoverflow.com/questions/58627085/jest-manual-mock-for-themeprovider
+
+import React from 'react';
+import PropTypes from 'prop-types';
+import { createTheme } from '@mui/material/styles';
+import { ThemeProvider } from '@mui/material';
+
+const MockTheme = ({ children }) => {
+  const theme = createTheme({});
+  return <ThemeProvider theme={theme}>{children}</ThemeProvider>;
+};
+
+MockTheme.propTypes = {
+  children: PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node]).isRequired,
+};
+
+export default MockTheme;

--- a/tests/MuiComponentsTesting/SliderTesting.js
+++ b/tests/MuiComponentsTesting/SliderTesting.js
@@ -16,7 +16,7 @@ export class SliderTesting {
   }
 
   get SliderValue() {
-    return document.querySelector('#slider-input input');
+    return document.querySelector('#slider-root input');
   }
 
   get SliderMarks() {

--- a/tests/MuiComponentsTesting/SliderTesting.js
+++ b/tests/MuiComponentsTesting/SliderTesting.js
@@ -2,11 +2,10 @@
 // Licensed under the MIT license.
 
 import { getByDataCy } from '../utils';
-import { getByRole } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 export class SliderTesting {
-  constructor({ dataCy, user }) {
+  constructor({ dataCy }) {
     this._dataCy = dataCy;
     this.user = userEvent.setup();
   }
@@ -25,23 +24,5 @@ export class SliderTesting {
 
   get SliderMarksValue() {
     return Array.from(document.getElementsByClassName('MuiSlider-markLabel')).map((mark) => mark.textContent);
-  }
-
-  get SliderTracker() {
-    return getByRole(this.Slider, 'slider');
-  }
-
-  async moveSliderToTheRight(handlingFunction, sentValue) {
-    await this.user.click(this.SliderTracker);
-    await this.user.keyboard('[ArrowRight]');
-    expect(handlingFunction).toBeCalled();
-    expect(handlingFunction).toHaveBeenCalledWith(sentValue);
-  }
-
-  async moveSliderToTheLeft(handlingFunction, sentValue) {
-    await this.user.click(this.SliderTracker);
-    await this.user.keyboard('[ArrowLeft]');
-    expect(handlingFunction).toBeCalled();
-    expect(handlingFunction).toHaveBeenCalledWith(sentValue);
   }
 }

--- a/tests/MuiComponentsTesting/index.js
+++ b/tests/MuiComponentsTesting/index.js
@@ -7,3 +7,4 @@ export { RadioGroupTesting } from './RadioGroupTesting';
 export { ChipTesting } from './ChipTesting';
 export { TypographyTesting } from './TypographyTesting';
 export { SelectTesting } from './SelectTesting';
+export { default as MockTheme } from './MockTheme';

--- a/tests/utils/index.js
+++ b/tests/utils/index.js
@@ -2,3 +2,4 @@
 // Licensed under the MIT license.
 
 export * from './getElementsUtils';
+export { renderInMuiThemeProvider } from './renderInMuiThemeProvider';

--- a/tests/utils/renderInMuiThemeProvider.js
+++ b/tests/utils/renderInMuiThemeProvider.js
@@ -1,0 +1,10 @@
+// Copyright (c) Cosmo Tech.
+// Licensed under the MIT license.
+
+import React from 'react';
+import { render } from '@testing-library/react';
+import { MockTheme } from '../MuiComponentsTesting';
+
+export const renderInMuiThemeProvider = (children) => {
+  return render(<MockTheme>{children}</MockTheme>);
+};


### PR DESCRIPTION
- add `ThemeProvider` wrapper for jest tests `render`
- fix jest tests following DOM changes during migration to mui v5
- remove jest tests asserting the value changes of `BasicSliderInput` component