### PR TITLE
fix: fix undesired resets of number input fields

### DIFF
--- a/src/inputs/BasicInputs/BasicNumberInput/BasicNumberInput.js
+++ b/src/inputs/BasicInputs/BasicNumberInput/BasicNumberInput.js
@@ -4,7 +4,7 @@
 import { Grid, Stack, TextField } from '@mui/material';
 import makeStyles from '@mui/styles/makeStyles';
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { BasicInputPlaceholder } from '../BasicInputPlaceholder';
 import { NumberFormatCustom } from '../../../misc/formatters';
 import { TooltipInfo } from '../../../misc/TooltipInfo';
@@ -16,6 +16,28 @@ export const BasicNumberInput = (props) => {
   const classes = useStyles();
   const { id, label, tooltipText, value, textFieldProps, inputProps, changeNumberField, isDirty, ...otherProps } =
     props;
+
+  const [textInput, setTextInput] = useState(value.toString());
+  useEffect(() => {
+    if (textInput && parseFloat(textInput) !== value) setTextInput(value.toString());
+  }, [value, textInput]);
+
+  const handleChangeEvent = useCallback(
+    (event) => {
+      setTextInput(event.target.value);
+      const inputValueAsNumber = parseFloat(event.target.value);
+      if (inputValueAsNumber !== value) changeNumberField(inputValueAsNumber);
+    },
+    [value, changeNumberField]
+  );
+
+  const handleBlurEvent = useCallback(() => {
+    const valueAsString = value.toString();
+    if (valueAsString !== textInput) {
+      setTextInput(valueAsString);
+    }
+  }, [value, textInput, setTextInput]);
+
   if (textFieldProps.disabled)
     return (
       <BasicInputPlaceholder
@@ -41,8 +63,9 @@ export const BasicNumberInput = (props) => {
           variant="outlined"
           label={label}
           size="small"
-          value={value}
-          onChange={(event) => changeNumberField(parseFloat(event.target.value))}
+          value={textInput}
+          onChange={handleChangeEvent}
+          onBlur={handleBlurEvent}
           inputProps={inputProps}
           InputProps={{
             inputComponent: NumberFormatCustom,


### PR DESCRIPTION
- use a local component state `textInput` to store the text data used inside in the input field
- when `value` prop changes, update `textInput` only if the new value is actually different from `textInput` (parsed to float)
- when `textInput` changes (when users edit the number input field), call the `onChange` prop function only if the new value  (parsed to float) is actually different from the `prop` value