### PR TITLE
test: add UT to check dirtyInput class in Basic inputs

### DIFF
--- a/jestSetup.js
+++ b/jestSetup.js
@@ -2,3 +2,8 @@
 // Licensed under the MIT license.
 
 import '@testing-library/jest-dom';
+import { toHaveDirtyInputClass } from './tests/extensions';
+
+expect.extend({
+  toHaveDirtyInputClass,
+});

--- a/src/inputs/BasicInputs/BasicDateInput/BasicDateInput.spec.js
+++ b/src/inputs/BasicInputs/BasicDateInput/BasicDateInput.spec.js
@@ -1,0 +1,43 @@
+/* eslint-disable react/prop-types */
+// Copyright (c) Cosmo Tech.
+// Licensed under the MIT license.
+
+import React from 'react';
+import { BasicDateInput } from './BasicDateInput';
+import { renderInMuiThemeProvider } from '../../../../tests/utils';
+import { StackContainerTesting } from '../../../../tests/MuiComponentsTesting';
+
+const mockOnValueChanged = jest.fn();
+
+const defaultProps = {
+  id: 'start-date',
+  value: new Date('03/30/2023'),
+  changeSelectedDate: mockOnValueChanged,
+  dateProps: {
+    disabled: false,
+  },
+};
+
+const propsWithDirtyState = {
+  ...defaultProps,
+  isDirty: true,
+};
+
+const dateInputContainer = new StackContainerTesting({ dataCy: 'date-input-start-date' });
+
+const setUp = (props) => {
+  renderInMuiThemeProvider(<BasicDateInput {...props} />);
+};
+
+describe('Checks date input in edit mode', () => {
+  test("Component is displayed in edit mode and dirtyInput class isn't applied when isDirty is false", () => {
+    setUp(defaultProps);
+    expect(dateInputContainer.Stack).toBeInTheDocument();
+    expect(dateInputContainer.Stack).not.toHaveDirtyInputClass();
+  });
+
+  test('dirtyInput class is applied when isDirty is true', () => {
+    setUp(propsWithDirtyState);
+    expect(dateInputContainer.Stack).toHaveDirtyInputClass();
+  });
+});

--- a/src/inputs/BasicInputs/BasicEnumInput/BasicEnumInput.spec.js
+++ b/src/inputs/BasicInputs/BasicEnumInput/BasicEnumInput.spec.js
@@ -1,0 +1,56 @@
+/* eslint-disable react/prop-types */
+// Copyright (c) Cosmo Tech.
+// Licensed under the MIT license.
+
+import React from 'react';
+import { BasicEnumInput } from './BasicEnumInput';
+import { renderInMuiThemeProvider } from '../../../../tests/utils';
+import { StackContainerTesting } from '../../../../tests/MuiComponentsTesting';
+
+const mockOnValueChanged = jest.fn();
+const defaultProps = {
+  id: 'currency',
+  value: 'EUR',
+  enumValues: [
+    {
+      key: 'USD',
+      value: '$',
+    },
+    {
+      key: 'EUR',
+      value: '€',
+    },
+    {
+      key: 'BTC',
+      value: '฿',
+    },
+    {
+      key: 'JPY',
+      value: '¥',
+    },
+  ],
+  textFieldProps: {
+    disabled: false,
+  },
+  changeEnumField: mockOnValueChanged,
+};
+const propsWithDirtyState = {
+  ...defaultProps,
+  isDirty: true,
+};
+const enumInputContainer = new StackContainerTesting({ dataCy: 'enum-input-currency' });
+const setUp = (props) => {
+  renderInMuiThemeProvider(<BasicEnumInput {...props} />);
+};
+
+describe('Checks enumInput in edit mode', () => {
+  test("Component is displayed in edit mode and dirtyInput class isn't applied when isDirty is false", () => {
+    setUp(defaultProps);
+    expect(enumInputContainer.Stack).toBeInTheDocument();
+    expect(enumInputContainer.Stack).not.toHaveDirtyInputClass();
+  });
+  test('dirtyInput class is applied when isDirty is true', () => {
+    setUp(propsWithDirtyState);
+    expect(enumInputContainer.Stack).toHaveDirtyInputClass();
+  });
+});

--- a/src/inputs/BasicInputs/BasicNumberInput/BasicNumberInput.spec.js
+++ b/src/inputs/BasicInputs/BasicNumberInput/BasicNumberInput.spec.js
@@ -1,0 +1,38 @@
+/* eslint-disable react/prop-types */
+// Copyright (c) Cosmo Tech.
+// Licensed under the MIT license.
+
+import React from 'react';
+import { BasicNumberInput } from './BasicNumberInput';
+import { renderInMuiThemeProvider } from '../../../../tests/utils';
+import { StackContainerTesting } from '../../../../tests/MuiComponentsTesting';
+
+const mockOnValueChanged = jest.fn();
+
+const defaultProps = {
+  id: 'stock',
+  value: 10,
+  textFieldProps: {
+    disabled: false,
+  },
+  changeNumberField: mockOnValueChanged,
+};
+const propsWithDirtyState = {
+  ...defaultProps,
+  isDirty: true,
+};
+const numberInputContainer = new StackContainerTesting({ dataCy: 'number-input-stock' });
+const setUp = (props) => {
+  renderInMuiThemeProvider(<BasicNumberInput {...props} />);
+};
+describe('Checks numberInput in editMode', () => {
+  test("Component is displayed in edit mode and dirtyInput class isn't applied when isDirty is false", () => {
+    setUp(defaultProps);
+    expect(numberInputContainer.Stack).toBeInTheDocument();
+    expect(numberInputContainer.Stack).not.toHaveDirtyInputClass();
+  });
+  test('dirtyInput class is applied when isDirty is true', () => {
+    setUp(propsWithDirtyState);
+    expect(numberInputContainer.Stack).toHaveDirtyInputClass();
+  });
+});

--- a/src/inputs/BasicInputs/BasicRadioInput/BasicRadioInput.spec.js
+++ b/src/inputs/BasicInputs/BasicRadioInput/BasicRadioInput.spec.js
@@ -1,0 +1,53 @@
+/* eslint-disable react/prop-types */
+// Copyright (c) Cosmo Tech.
+// Licensed under the MIT license.
+
+import React from 'react';
+import { BasicRadioInput } from './BasicRadioInput';
+import { renderInMuiThemeProvider } from '../../../../tests/utils';
+import { StackContainerTesting } from '../../../../tests/MuiComponentsTesting';
+
+const mockOnValueChanged = jest.fn();
+const radioInputContainer = new StackContainerTesting({ dataCy: 'radio-input-unit' });
+const defaultProps = {
+  id: 'unit',
+  value: 'LITRE',
+  textFieldProps: {
+    disabled: false,
+  },
+  enumValues: [
+    {
+      key: 'LITRE',
+      value: 'L',
+    },
+    {
+      key: 'BARREL',
+      value: 'bl',
+    },
+    {
+      key: 'CUBIC_METRE',
+      value: 'm³',
+    },
+  ],
+  changeRadioOption: mockOnValueChanged,
+};
+
+const propsWithDirtyState = {
+  ...defaultProps,
+  isDirty: true,
+};
+const setUp = (props) => {
+  renderInMuiThemeProvider(<BasicRadioInput {...props} />);
+};
+
+describe('Checks radio input in edit mode', () => {
+  test("Component is displayed in edit mode and dirtyInput class isn't applied when isDirty is false", () => {
+    setUp(defaultProps);
+    expect(radioInputContainer.Stack).toBeInTheDocument();
+    expect(radioInputContainer.Stack).not.toHaveDirtyInputClass();
+  });
+  test('dirtyInput class is applied when isDirty is true', () => {
+    setUp(propsWithDirtyState);
+    expect(radioInputContainer.Stack).toHaveDirtyInputClass();
+  });
+});

--- a/src/inputs/BasicInputs/BasicSliderInput/BasicSliderInput.spec.js
+++ b/src/inputs/BasicInputs/BasicSliderInput/BasicSliderInput.spec.js
@@ -4,9 +4,8 @@
 
 import React from 'react';
 import { BasicSliderInput } from './BasicSliderInput';
-import { SliderTesting } from '../../../../tests/MuiComponentsTesting/SliderTesting';
+import { SliderTesting, TypographyTesting, StackContainerTesting } from '../../../../tests/MuiComponentsTesting';
 import { renderInMuiThemeProvider } from '../../../../tests/utils';
-import { TypographyTesting } from '../../../../tests/MuiComponentsTesting';
 
 const mockOnValueChanged = jest.fn();
 
@@ -38,10 +37,15 @@ const propsInEditMode = {
   ...defaultProps,
   disabled: false,
 };
+const propsWithDirtyState = {
+  ...propsInEditMode,
+  isDirty: true,
+};
 
 const disabledSliderLabel = new TypographyTesting({ dataCy: 'disabled-input-label' });
 const disabledSliderValue = new TypographyTesting({ dataCy: 'disabled-input-value' });
 const sliderEditMode = new SliderTesting({ dataCy: 'slider-input-average_consumption' });
+const sliderEditModeContainer = new StackContainerTesting({ dataCy: 'slider-input-average_consumption' });
 
 const setUp = (props) => {
   renderInMuiThemeProvider(<BasicSliderInput {...props} />);
@@ -74,6 +78,10 @@ describe('BasicSliderInput tests in disabled and edit mode', () => {
       expect(sliderEditMode.SliderValue).toHaveValue(propsInEditMode.value.toString());
     });
 
+    test('Checks dirtyInput class is not applied when isDirty is false', () => {
+      expect(sliderEditModeContainer.Stack).not.toHaveDirtyInputClass();
+    });
+
     test('Checks marks of slider in edit mode', () => {
       expect(sliderEditMode.SliderMarks[0]).toBeInTheDocument();
       expect(sliderEditMode.SliderMarks[1]).toBeInTheDocument();
@@ -97,5 +105,9 @@ describe('BasicSliderInput tests in disabled and edit mode', () => {
       setUp(propsWithNaNValue);
       expect(disabledSliderValue.text).toEqual('0');
     });
+  });
+  describe('Checks dirtyInput style is applied when isDirty is true', () => {
+    setUp(propsWithDirtyState);
+    expect(sliderEditModeContainer.Stack).toHaveDirtyInputClass();
   });
 });

--- a/src/inputs/BasicInputs/BasicTextInput/BasicTextInput.spec.js
+++ b/src/inputs/BasicInputs/BasicTextInput/BasicTextInput.spec.js
@@ -1,0 +1,39 @@
+/* eslint-disable react/prop-types */
+// Copyright (c) Cosmo Tech.
+// Licensed under the MIT license.
+
+import React from 'react';
+import { BasicTextInput } from './BasicTextInput';
+import { renderInMuiThemeProvider } from '../../../../tests/utils';
+import { StackContainerTesting } from '../../../../tests/MuiComponentsTesting';
+
+const mockOnValueChanged = jest.fn();
+const textInputContainer = new StackContainerTesting({ dataCy: 'text-input-comment' });
+const defaultProps = {
+  id: 'comment',
+  value: 'short comment',
+  textFieldProps: {
+    disabled: false,
+  },
+  changeTextField: mockOnValueChanged,
+};
+
+const propsWithDirtyState = {
+  ...defaultProps,
+  isDirty: true,
+};
+const setUp = (props) => {
+  renderInMuiThemeProvider(<BasicTextInput {...props} />);
+};
+
+describe('Checks text input in edit mode', () => {
+  test("Component is displayed in edit mode and dirtyInput class isn't applied when isDirty is false", () => {
+    setUp(defaultProps);
+    expect(textInputContainer.Stack).toBeInTheDocument();
+    expect(textInputContainer.Stack).not.toHaveDirtyInputClass();
+  });
+  test('dirtyInput class is applied when isDirty is true', () => {
+    setUp(propsWithDirtyState);
+    expect(textInputContainer.Stack).toHaveDirtyInputClass();
+  });
+});

--- a/src/inputs/BasicInputs/BasicToggleInput/BasicToggleInput.spec.js
+++ b/src/inputs/BasicInputs/BasicToggleInput/BasicToggleInput.spec.js
@@ -1,0 +1,39 @@
+/* eslint-disable react/prop-types */
+// Copyright (c) Cosmo Tech.
+// Licensed under the MIT license.
+
+import React from 'react';
+import { BasicToggleInput } from './BasicToggleInput';
+import { renderInMuiThemeProvider } from '../../../../tests/utils';
+import { StackContainerTesting } from '../../../../tests/MuiComponentsTesting';
+
+const mockOnValueChanged = jest.fn();
+const toggleInputContainer = new StackContainerTesting({ dataCy: 'toggle-input-enabled' });
+const defaultProps = {
+  id: 'enabled',
+  value: true,
+  switchProps: {
+    disabled: false,
+  },
+  changeSwitchType: mockOnValueChanged,
+};
+
+const propsWithDirtyState = {
+  ...defaultProps,
+  isDirty: true,
+};
+const setUp = (props) => {
+  renderInMuiThemeProvider(<BasicToggleInput {...props} />);
+};
+
+describe('Checks toggle input in edit mode', () => {
+  test("Component is displayed in edit mode and dirtyInput class isn't applied when isDirty is false", () => {
+    setUp(defaultProps);
+    expect(toggleInputContainer.Stack).toBeInTheDocument();
+    expect(toggleInputContainer.Stack).not.toHaveDirtyInputClass();
+  });
+  test('dirtyInput class is applied when isDirty is true', () => {
+    setUp(propsWithDirtyState);
+    expect(toggleInputContainer.Stack).toHaveDirtyInputClass();
+  });
+});

--- a/src/inputs/Table/Table.js
+++ b/src/inputs/Table/Table.js
@@ -136,7 +136,12 @@ export const Table = (props) => {
   }, [rows]);
 
   return (
-    <div id="table-container" {...otherProps} className={isDirty ? classes.dirtyInput : classes.notDirtyInput}>
+    <div
+      id="table-container"
+      data-cy="table-input"
+      {...otherProps}
+      className={isDirty ? classes.dirtyInput : classes.notDirtyInput}
+    >
       <div data-cy="label">
         <Stack spacing={1} direction="row" alignItems="center">
           <Typography variant="subtitle2" sx={{ fontWeight: 'bold' }} color="textSecondary">

--- a/src/inputs/Table/Table.spec.js
+++ b/src/inputs/Table/Table.spec.js
@@ -1,0 +1,44 @@
+/* eslint-disable react/prop-types */
+// Copyright (c) Cosmo Tech.
+// Licensed under the MIT license.
+
+import React from 'react';
+import { Table } from './Table';
+import { renderInMuiThemeProvider } from '../../../tests/utils';
+import { StackContainerTesting } from '../../../tests/MuiComponentsTesting';
+
+const mockOnClearErrors = jest.fn();
+const tableInputContainer = new StackContainerTesting({ dataCy: 'table-input' });
+const defaultProps = {
+  editMode: true,
+  columns: [
+    { field: 'a', type: ['string'] },
+    { field: 'b', type: ['int'] },
+    { field: 'c', type: ['bool'] },
+  ],
+  rows: [
+    { a: 'foo', b: '12', c: 'false' },
+    { a: 'bar', b: '53', c: 'true' },
+  ],
+  onClearErrors: mockOnClearErrors,
+};
+
+const propsWithDirtyState = {
+  ...defaultProps,
+  isDirty: true,
+};
+const setUp = (props) => {
+  renderInMuiThemeProvider(<Table {...props} />);
+};
+
+describe('Checks table input in edit mode', () => {
+  test("Component is displayed in edit mode and dirtyInput class isn't applied when isDirty is false", () => {
+    setUp(defaultProps);
+    expect(tableInputContainer.Stack).toBeInTheDocument();
+    expect(tableInputContainer.Stack).not.toHaveDirtyInputClass();
+  });
+  test('dirtyInput class is applied when isDirty is true', () => {
+    setUp(propsWithDirtyState);
+    expect(tableInputContainer.Stack).toHaveDirtyInputClass();
+  });
+});

--- a/src/inputs/UploadFile/UploadFile.spec.js
+++ b/src/inputs/UploadFile/UploadFile.spec.js
@@ -1,0 +1,41 @@
+/* eslint-disable react/prop-types */
+// Copyright (c) Cosmo Tech.
+// Licensed under the MIT license.
+
+import React from 'react';
+import { UploadFile } from './UploadFile';
+import { renderInMuiThemeProvider } from '../../../tests/utils';
+import { StackContainerTesting } from '../../../tests/MuiComponentsTesting';
+
+const mockOnFileUpload = jest.fn();
+const mockOnFileDelete = jest.fn();
+const mockOnFileDownload = jest.fn();
+const uploadFileInputContainer = new StackContainerTesting({ dataCy: 'file-upload-dataset' });
+const defaultProps = {
+  id: 'dataset',
+  file: {},
+  handleUploadFile: mockOnFileUpload,
+  handleDeleteFile: mockOnFileDelete,
+  handleDownloadFile: mockOnFileDownload,
+  editMode: true,
+};
+
+const propsWithDirtyState = {
+  ...defaultProps,
+  isDirty: true,
+};
+const setUp = (props) => {
+  renderInMuiThemeProvider(<UploadFile {...props} />);
+};
+
+describe('Checks file upload input in edit mode', () => {
+  test("Component is displayed in edit mode and dirtyInput class isn't applied when isDirty is false", () => {
+    setUp(defaultProps);
+    expect(uploadFileInputContainer.Stack).toBeInTheDocument();
+    expect(uploadFileInputContainer.Stack).not.toHaveDirtyInputClass();
+  });
+  test('dirtyInput class is applied when isDirty is true', () => {
+    setUp(propsWithDirtyState);
+    expect(uploadFileInputContainer.Stack).toHaveDirtyInputClass();
+  });
+});

--- a/tests/MuiComponentsTesting/StackContainerTesting.js
+++ b/tests/MuiComponentsTesting/StackContainerTesting.js
@@ -1,0 +1,14 @@
+// Copyright (c) Cosmo Tech.
+// Licensed under the MIT license.
+
+import { getByDataCy } from '../utils';
+
+export class StackContainerTesting {
+  constructor({ dataCy }) {
+    this._dataCy = dataCy;
+  }
+
+  get Stack() {
+    return getByDataCy(this._dataCy);
+  }
+}

--- a/tests/MuiComponentsTesting/index.js
+++ b/tests/MuiComponentsTesting/index.js
@@ -7,4 +7,6 @@ export { RadioGroupTesting } from './RadioGroupTesting';
 export { ChipTesting } from './ChipTesting';
 export { TypographyTesting } from './TypographyTesting';
 export { SelectTesting } from './SelectTesting';
+export { SliderTesting } from './SliderTesting';
+export { StackContainerTesting } from './StackContainerTesting';
 export { default as MockTheme } from './MockTheme';

--- a/tests/extensions/index.js
+++ b/tests/extensions/index.js
@@ -1,0 +1,4 @@
+// Copyright (c) Cosmo Tech.
+// Licensed under the MIT license.
+
+export { toHaveDirtyInputClass } from './toHaveDirtyInputClass';

--- a/tests/extensions/toHaveDirtyInputClass.js
+++ b/tests/extensions/toHaveDirtyInputClass.js
@@ -1,0 +1,13 @@
+// Copyright (c) Cosmo Tech.
+// Licensed under the MIT license.
+
+import '@testing-library/jest-dom';
+
+export function toHaveDirtyInputClass(received) {
+  if (this.isNot) {
+    expect(received).not.toHaveAttribute('class', expect.stringContaining('dirtyInput'));
+  } else {
+    expect(received).toHaveAttribute('class', expect.stringContaining('dirtyInput'));
+  }
+  return { pass: !this.isNot };
+}


### PR DESCRIPTION
Add UT to check `dirtyInput` class in basic inputs: create a custom matcher `toHaveDirtyClass` and implement the test for every file. 