### PR TITLE
fix!: remove forced datasets filter on tags in CreateScenarioButton

### DIFF
--- a/src/buttons/CreateScenarioButton/CreateScenarioButton.js
+++ b/src/buttons/CreateScenarioButton/CreateScenarioButton.js
@@ -19,10 +19,6 @@ export const CreateScenarioButton = ({
   const [open, setOpen] = useState(false);
   const openDialog = () => setOpen(true);
   const closeDialog = () => setOpen(false);
-  const datasetsFilter = (dataset) => {
-    if (dataset.tags === null) return false;
-    return dataset.tags.includes('dataset');
-  };
 
   return (
     <div>
@@ -49,7 +45,6 @@ export const CreateScenarioButton = ({
         runTemplates={runTemplates}
         scenarios={scenarios}
         user={user}
-        datasetsFilter={datasetsFilter}
         dialogLabels={labels.dialog}
         errorLabels={labels.errors}
       />

--- a/src/buttons/CreateScenarioButton/components/CreateScenarioDialog/CreateScenarioDialog.js
+++ b/src/buttons/CreateScenarioButton/components/CreateScenarioDialog/CreateScenarioDialog.js
@@ -58,14 +58,12 @@ const CreateScenarioDialog = ({
   createScenario,
   workspaceId,
   solution,
-  datasetsFilter,
   dialogLabels,
   errorLabels,
 }) => {
   const classes = useStyles();
 
-  const filteredDatasets = datasetsFilter ? datasets.filter(datasetsFilter) : datasets;
-  const defaultDataset = filteredDatasets.length > 0 ? filteredDatasets[0] : dialogLabels.datasetPlaceholder;
+  const defaultDataset = datasets.length > 0 ? datasets[0] : dialogLabels.datasetPlaceholder;
   const defaultRunTemplate = runTemplates?.[0] || null;
   const currentScenarioSelected = currentScenario.data !== null;
 
@@ -199,7 +197,7 @@ const CreateScenarioDialog = ({
                 ListboxProps={{ 'data-cy': 'create-scenario-dialog-dataset-select-options' }}
                 id="dataset"
                 disableClearable={true}
-                options={filteredDatasets}
+                options={datasets}
                 value={datasetFieldValues}
                 onChange={(event, newDataset) => setDatasetFieldValues(newDataset)}
                 getOptionLabel={(option) => option.name ?? ''}
@@ -274,7 +272,6 @@ CreateScenarioDialog.propTypes = {
   createScenario: PropTypes.func.isRequired,
   workspaceId: PropTypes.string.isRequired,
   solution: PropTypes.object.isRequired,
-  datasetsFilter: PropTypes.func,
   dialogLabels: PropTypes.shape({
     title: PropTypes.string.isRequired,
     scenarioName: PropTypes.string.isRequired,


### PR DESCRIPTION
BREAKING CHANGE: the list of datasets provided to the CreateScenarioButton component will no longer be filtered, showing the whole list of datasets when creating a new scenario, including the datasets that don't have the tag "dataset". If your webapp still needs this behavior, add the filter mechanism before forwarding the list of datasets to the props of CreateScenarioButton.