### PR TITLE
fix: fix tooltip not disappearing when toggling fullscreen mode in Table

### DIFF
--- a/src/inputs/Table/components/TableToolbar/components/FullscreenButton/FullscreenButton.js
+++ b/src/inputs/Table/components/TableToolbar/components/FullscreenButton/FullscreenButton.js
@@ -1,6 +1,6 @@
 // Copyright (c) Cosmo Tech.
 // Licensed under the MIT license.
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 import PropTypes from 'prop-types';
 import CloseFullscreenIcon from '@mui/icons-material/CloseFullscreen';
 import OpenInFullIcon from '@mui/icons-material/OpenInFull';
@@ -11,10 +11,21 @@ export const FullscreenButton = (props) => {
   const { isFullscreen, toggleFullscreen, disabled, label } = props;
   const spanProps = { style: { display: 'inline-block', height: '100%' } };
 
+  const [isTooltipOpen, setTooltipOpen] = useState(false);
+  const onClick = useCallback(
+    (event) => {
+      setTooltipOpen(false);
+      toggleFullscreen(event);
+    },
+    [setTooltipOpen, toggleFullscreen]
+  );
+
   return (
-    <FadingTooltip title={label} useSpan={true} spanProps={spanProps} disableInteractive={true}>
+    <FadingTooltip open={isTooltipOpen} title={label} useSpan={true} spanProps={spanProps} disableInteractive={true}>
       <IconButton
-        onClick={toggleFullscreen}
+        onClick={onClick}
+        onMouseEnter={() => setTooltipOpen(true)}
+        onMouseLeave={() => setTooltipOpen(false)}
         size="small"
         data-cy="grid-fullscreen-button"
         color="primary"


### PR DESCRIPTION
This commit makes us of the controlled mode of MUI Tooltip to force close the tooltip when the fullscreen mode is toggled.

The work-around right now is to click outside of the tooltip to make it disappear.